### PR TITLE
Clarifications on Homework 12

### DIFF
--- a/week12/hw/README.md
+++ b/week12/hw/README.md
@@ -11,9 +11,11 @@ A. __Get three virtual servers provisioned__, 2 vCPUs, 4G RAM, UBUNTU\_16\_64, _
 
 B. __Set up each one of your nodes as follows:__
 
-Add to /root/.bash\_profile the following line in the end:
+Add to /root/.profile the following line in the end:
 
     export PATH=$PATH:/usr/lpp/mmfs/bin
+    
+Then execute the command `source ~/.profile` to commit the extra path to your `$PATH` variable.
 
 Make sure the nodes can talk to each other without a password.  When you created the VMs, you specified a keypair.  Copy it to /root/.ssh/id\_rsa (copy paste or scp works).  Set its permissions:
 

--- a/week12/hw/README.md
+++ b/week12/hw/README.md
@@ -86,6 +86,12 @@ You could get more details on your cluster:
 
     mmlscluster
 
+If a node doesn't appear for some reason (for example, if there was a connection issue when the cluster was initially created), you can manually the node in with the command `mmaddnode`:
+    
+    mmaddnode -N gpfs3
+
+Where `gpfs3` is the name of the missing node.
+
 Now we need to define our disks. Do this to print the paths and sizes of disks on your machine:
 
     fdisk -l

--- a/week12/hw/README.md
+++ b/week12/hw/README.md
@@ -108,7 +108,7 @@ Now inspect the mount location of the root filesystem on your boxes:
     [root@gpfs1 ras]# mount | grep ' \/ '
     /dev/xvda2 on / type ext3 (rw,noatime)
 
-Disk /dev/xvda (partition 2) is where my operating system is installed, so I'm going to leave it alone.  In my case, __xvdc__ is my 100 disk.  In your case, it could be /dev/xvdb, so __please be careful here__.  Assuming your second disk is `/dev/xvdc` then add these lines to `/root/diskfile.fpo`:
+Disk /dev/xvda (partition 2) is where my operating system is installed, so I'm going to leave it alone.  In my case, __xvdc__ is my 100 disk.  In your case, it could be /dev/xvdb, so __please be careful here__.  Assuming your second disk is `/dev/xvdc` then add these lines to `/root/diskfile.fpo` on gpfs1:
 
     %pool:
     pool=system


### PR DESCRIPTION
Made some minor updates:

- Ubuntu doesn't ship with `.bash_profile` so I updated the instruction to use `.profile` instead. Also, added a note to source the file so the update to `$PATH` actually takes hold on each VSI.
- Added instruction for how to add a node to the GPFS cluster after the cluster is already created. When I created my cluster, connection to `gpfs3` failed so only `gpfs1` and `gpfs2` were in my cluster. It didn't even say that `gpfs3` was down, so I added notes on how to do it.
 - Added a small note that you only need to create the `diskfile.fpo` file on the headnode. 